### PR TITLE
feat: add colored filter-group badges to distinguish domain and type filters

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -49,6 +49,45 @@ body {
 ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.2); }
 
+/* 过滤器分组标签 */
+.filter-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  border-radius: 6px 0 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  border-right: none;
+  font-family: var(--font-ui);
+  line-height: 1.4;
+}
+
+.filter-badge-domain {
+  background: rgba(0, 245, 255, 0.12);
+  color: var(--primary);
+  border-color: rgba(0, 245, 255, 0.25);
+}
+
+.filter-badge-type {
+  background: rgba(112, 0, 255, 0.12);
+  color: var(--secondary);
+  border-color: rgba(112, 0, 255, 0.25);
+}
+
+.filter-group .filter-select {
+  border-radius: 0 6px 6px 0;
+  border-left: none;
+}
+
 /* Loader2 spin safety net */
 @keyframes spin {
   from { transform: rotate(0deg); }

--- a/web/components/toolbar/Toolbar.tsx
+++ b/web/components/toolbar/Toolbar.tsx
@@ -130,43 +130,49 @@ export default function Toolbar() {
 
       {/* Filters */}
       <div style={{ display: 'flex', gap: 4 }}>
-        <select
-          value={domainFilter}
-          onChange={e => setDomainFilter(e.target.value)}
-          style={{
-            background: 'rgba(0,0,0,0.04)',
-            border: '1px solid transparent',
-            borderRadius: 6,
-            color: 'var(--text-secondary)',
-            padding: '4px 6px',
-            fontSize: 12,
-            fontFamily: 'var(--font-ui)',
-            cursor: 'pointer',
-            outline: 'none',
-          }}
-        >
-          <option value="">领域</option>
-          {domains.map(d => <option key={d} value={d}>{d}</option>)}
-        </select>
+        <span className="filter-group">
+          <span className="filter-badge filter-badge-domain">领域</span>
+          <select
+            value={domainFilter}
+            onChange={e => setDomainFilter(e.target.value)}
+            className="filter-select"
+            style={{
+              background: 'rgba(0,0,0,0.04)',
+              border: '1px solid transparent',
+              color: 'var(--text-secondary)',
+              padding: '4px 6px',
+              fontSize: 12,
+              fontFamily: 'var(--font-ui)',
+              cursor: 'pointer',
+              outline: 'none',
+            }}
+          >
+            <option value="">全部</option>
+            {domains.map(d => <option key={d} value={d}>{d}</option>)}
+          </select>
+        </span>
 
-        <select
-          value={typeFilter}
-          onChange={e => setTypeFilter(e.target.value)}
-          style={{
-            background: 'rgba(0,0,0,0.04)',
-            border: '1px solid transparent',
-            borderRadius: 6,
-            color: 'var(--text-secondary)',
-            padding: '4px 6px',
-            fontSize: 12,
-            fontFamily: 'var(--font-ui)',
-            cursor: 'pointer',
-            outline: 'none',
-          }}
-        >
-          <option value="">类型</option>
-          {types.map(t => <option key={t} value={t}>{t}</option>)}
-        </select>
+        <span className="filter-group">
+          <span className="filter-badge filter-badge-type">类型</span>
+          <select
+            value={typeFilter}
+            onChange={e => setTypeFilter(e.target.value)}
+            className="filter-select"
+            style={{
+              background: 'rgba(0,0,0,0.04)',
+              border: '1px solid transparent',
+              color: 'var(--text-secondary)',
+              padding: '4px 6px',
+              fontSize: 12,
+              fontFamily: 'var(--font-ui)',
+              cursor: 'pointer',
+              outline: 'none',
+            }}
+          >
+            <option value="">全部</option>
+            {types.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </span>
       </div>
 
       {/* Stats */}


### PR DESCRIPTION
## Summary
为过滤器的领域和类型标签添加彩色分组徽章，用户可以一眼区分不同的过滤器分组。

## Changes
- `web/components/toolbar/Toolbar.tsx` - 渲染逻辑中添加分组标记
- `web/app/globals.css` - 新增 19 行样式

Closes #9