### PR TITLE
fix(graph): persist node visibility during rapid filtering (#52)

### DIFF
--- a/web/components/graph/ForceGraph.tsx
+++ b/web/components/graph/ForceGraph.tsx
@@ -163,11 +163,9 @@ export default function ForceGraph() {
     };
   }, []);
 
-  // Auto-fit after data changes (e.g. filter / click), but only once
-  const prevNodesLen = useRef(nodes.length);
+  // Auto-fit after data changes (e.g. filter / click)
   useEffect(() => {
-    if (fgRef.current && nodes.length > 0 && prevNodesLen.current !== nodes.length) {
-      prevNodesLen.current = nodes.length;
+    if (fgRef.current && nodes.length > 0) {
       // Reheat + resume after layout changes (filter, etc.)
       setTimeout(() => {
         if (!fgRef.current) return;
@@ -182,14 +180,14 @@ export default function ForceGraph() {
           }
         } else {
           // Multi-node: use standard zoomToFit.
-          fgRef.current.centerAt(dims.w / 2, dims.h / 2, 1);
+          fgRef.current.centerAt(0, 0, 1);
           fgRef.current.zoomToFit(800, 100);
           fgRef.current.d3ReheatSimulation();
           fgRef.current.resumeAnimation();
         }
       }, 100);
     }
-  }, [nodes, dims]);
+  }, [nodes]); // Trigger whenever node set changes (including filtering)
 
   // Let simulation settle on initial load. After ~3s alpha decays enough that
   // the RAF naturally exits (doRedraw = false when engine stops). We do NOT call
@@ -554,13 +552,14 @@ function buildGraphData(
   const links: Array<{ source: string; target: string; score?: number }> = [];
   const seenNodes = new Set<string>();
 
-  // Active set: nodes that pass filters AND are not ghosts
+  // Active set: nodes that pass filters
   const activeIds = new Set<string>();
   for (const [id, entry] of Object.entries(index.index)) {
     if (domainFilter && entry.domain !== domainFilter) continue;
     if (typeFilter && entry.type !== typeFilter) continue;
     if (q && !entry.title.toLowerCase().includes(q) && !entry.bodyPreview?.toLowerCase().includes(q)) continue;
-    if (levelMap.get(id) === 'ghost') continue;
+    // Keep ghost nodes in the simulation if they pass global filters,
+    // so their physical state persists even when dimmed.
     activeIds.add(id);
   }
 


### PR DESCRIPTION
## Summary

解决了连续点击节点过程中，非周边节点被物理性移除导致的状态丢失问题。

1. **节点持久化**：只要节点满足全局过滤条件（领域/类型/搜索），即使是在选中状态下的 `ghost` (淡化) 节点，也会被保留在 `nodes` 数组中。这样物理引擎会一直维护其坐标，不会在再次点击时因为「重新出现」而重置到原点。
2. **强制重新居中**：去掉了 `prevNodesLen` 限制，确保每次节点集合变化（哪怕数量没变）都会重新执行 Auto-fit 居中。
3. **少节点居中优化**：统一使用物理世界 (0,0) 坐标作为 `centerAt` 目标，配合少节点时的 `fx/fy` 固定逻辑。

## Test Plan

- [x] Run `npx playwright test e2e/graph-stability.spec.ts` -> Filtering tests pass.
- [ ] 连续点击多个节点，所有节点物理位置应保持稳定，不会消失。