### PR TITLE
fix: path traversal, canvas perf, YAML arrays, and React re-renders

### DIFF
--- a/web/app/api/notes/update/route.ts
+++ b/web/app/api/notes/update/route.ts
@@ -52,8 +52,11 @@ function buildFrontmatter(fm: Record<string, unknown>): string {
     } else if (typeof value === 'number') {
       lines.push(`${key}: ${value}`);
     } else if (Array.isArray(value)) {
-      const items = value.map(v => `"${String(v).replace(/"/g, '\\"')}"`).join(', ');
-      lines.push(`${key}: [${items}]`);
+      // Use proper YAML multi-line list format
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - "${String(item).replace(/"/g, '\\"')}"`);
+      }
     } else {
       lines.push(`${key}: "${String(value).replace(/"/g, '\\"')}"`);
     }

--- a/web/app/api/notes/update/route.ts
+++ b/web/app/api/notes/update/route.ts
@@ -12,13 +12,20 @@ export async function PATCH(req: NextRequest) {
     }
 
     // notePath: "notes/录音笔记/uuid.md"（相对于 public/）
-    const fullPath = path.join(process.cwd(), 'public', notePath);
+    const baseDir = path.resolve(process.cwd(), 'public');
+    const fullPath = path.join(baseDir, notePath);
 
-    if (!fs.existsSync(fullPath)) {
+    // Prevent path traversal: ensure resolved path is within baseDir
+    const resolvedPath = path.resolve(fullPath);
+    if (!resolvedPath.startsWith(baseDir + path.sep)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    if (!fs.existsSync(resolvedPath)) {
       return NextResponse.json({ error: 'Note file not found' }, { status: 404 });
     }
 
-    const content = fs.readFileSync(fullPath, 'utf8');
+    const content = fs.readFileSync(resolvedPath, 'utf8');
     const bodyStart = content.indexOf('\n---\n', 4);
     if (bodyStart < 0) {
       return NextResponse.json({ error: 'Invalid markdown format' }, { status: 500 });
@@ -27,7 +34,7 @@ export async function PATCH(req: NextRequest) {
     const body = content.slice(bodyStart + 5);
     const newFm = buildFrontmatter(frontmatter);
     const newContent = `${newFm}\n---\n${body}`;
-    fs.writeFileSync(fullPath, '\uFEFF' + newContent, 'utf8');
+    fs.writeFileSync(resolvedPath, '\uFEFF' + newContent, 'utf8');
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/web/app/api/source/[...path]/route.ts
+++ b/web/app/api/source/[...path]/route.ts
@@ -24,22 +24,29 @@ export async function GET(
 ) {
   const { path: pathParts } = await context.params;
   // source/ is at the project root, one level up from the Next.js web/ directory
-  const filePath = path.join(process.cwd(), '..', 'source', ...pathParts);
+  const baseDir = path.resolve(process.cwd(), '..', 'source');
+  const filePath = path.join(baseDir, ...pathParts);
 
-  if (!fs.existsSync(filePath)) {
+  // Prevent path traversal: ensure resolved path is within baseDir
+  const resolvedPath = path.resolve(filePath);
+  if (!resolvedPath.startsWith(baseDir + path.sep)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
     return new NextResponse('Not found', { status: 404 });
   }
 
-  const stat = fs.statSync(filePath);
+  const stat = fs.statSync(resolvedPath);
   if (stat.isDirectory()) {
     return new NextResponse('Not found', { status: 404 });
   }
 
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = path.extname(resolvedPath).toLowerCase();
   const contentType = CONTENT_TYPES[ext] ?? 'application/octet-stream';
 
   try {
-    const content = fs.readFileSync(filePath);
+    const content = fs.readFileSync(resolvedPath);
     return new NextResponse(content, {
       status: 200,
       headers: { 'Content-Type': contentType },

--- a/web/components/graph/ForceGraph.tsx
+++ b/web/components/graph/ForceGraph.tsx
@@ -87,6 +87,9 @@ export default function ForceGraph() {
   const autoFitSkipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track previous node count to detect removals vs additions
   const prevNodeCountRef = useRef(0);
+  // Pulse time ref: updated via rAF, avoids Date.now() in canvas callback
+  const pulseTimeRef = useRef(0);
+  const pulseRafRef = useRef<number | null>(null);
   const [dims, setDims] = useState({ w: 800, h: 600 });
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
   const [zoomState, setZoomState] = useState<{ x: number; y: number; k: number }>({ x: dims.w / 2, y: dims.h / 2, k: 1 });
@@ -241,7 +244,20 @@ export default function ForceGraph() {
     return () => {
       if (autoFitSkipTimerRef.current) clearTimeout(autoFitSkipTimerRef.current);
       if (dragEndTimerRef.current) clearTimeout(dragEndTimerRef.current);
+      if (pulseRafRef.current) cancelAnimationFrame(pulseRafRef.current);
     };
+  }, []);
+
+  // rAF loop for canvas pulse animation — drives nodeCanvasObject without Date.now()
+  useEffect(() => {
+    let rafId: number;
+    const tick = () => {
+      pulseTimeRef.current = performance.now();
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    pulseRafRef.current = rafId;
+    return () => cancelAnimationFrame(rafId);
   }, []);
 
   const trailLinkSet = useMemo(() => new Set(
@@ -391,7 +407,7 @@ export default function ForceGraph() {
 
     // Breathing glow for current location
     if (isCurrent) {
-      const pulse = (Math.sin(Date.now() / 400) + 1) / 2;
+      const pulse = (Math.sin(pulseTimeRef.current / 400) + 1) / 2;
       ctx.shadowColor = isTrajectory ? '#7C3AED' : '#F59E0B';
       ctx.shadowBlur = 10 + pulse * 15;
     }

--- a/web/components/panels/RightPanel.tsx
+++ b/web/components/panels/RightPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useGraphStore } from '@/stores/graphStore';
 import { loadNote, NoteContent } from '@/lib/note';
 import { X, Sparkles, Loader2 } from 'lucide-react';
@@ -224,7 +224,7 @@ export default function RightPanel() {
         {/* Footer: path-aware recommendations */}
         <div style={{ padding: '12px 18px', borderTop: '1px solid var(--border)', fontFamily: 'var(--font-ui)' }}>
           {/* 链路感知推荐 */}
-          {(() => {
+          {useMemo(() => {
             const recommendations = getPathAwareRecommendations(
               browsePath ?? [],
               selectedNodeId,
@@ -267,7 +267,7 @@ export default function RightPanel() {
                 </div>
               </>
             );
-          })()}
+          }, [browsePath, selectedNodeId, graphIndex])}
         </div>
       </motion.aside>
   );


### PR DESCRIPTION
## Summary

- **Path traversal guard** in `notes/update` — prevents writing outside `public/` directory
- **YAML array serialization** — fixes multi-line list format instead of inline JSON-style arrays
- **Canvas 60fps fix** — replaces `Date.now()` in `nodeCanvasObject` with `rAF`-driven `pulseTimeRef` to eliminate forced re-renders
- **React perf** — wraps `getPathAwareRecommendations` in `useMemo` in `RightPanel`

## Test plan

- [ ] Verify `PATCH /api/notes/update` rejects paths with `../` traversal attempts (403)
- [ ] Verify notes with tags arrays serialize to correct YAML multi-line format
- [ ] Verify graph canvas glow animation still works without 60fps CPU spike
- [ ] Verify recommendations re-compute only when `browsePath`/`selectedNodeId`/`graphIndex` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)